### PR TITLE
Fix typo and endmarker in configd_ctl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Issue reports
 
 Issue reports can be bug reports or feature requests.  Make sure to
 search the open and closed issues before adding a new one.  It is
-often better to join an ongoing discussions on similar open issues
+often better to join ongoing discussions on similar open issues
 than creating a new one as there may be workarounds or ideas available.
 
 When creating bug reports, please make sure you provide the following:

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -391,7 +391,7 @@ function filter_configure_sync($verbose = false, $load_aliases = true)
     }
 
     /*
-     * check for a error while loading the rules file.  if an error has occurred
+    * check for an error while loading the rules file.  if an error has occurred
      * then output the contents of the error to the caller
      */
     if ($rules_loading) {

--- a/src/opnsense/mvc/app/controllers/OPNsense/Syslog/forms/local.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Syslog/forms/local.xml
@@ -9,7 +9,7 @@
         <id>syslog.general.maxpreserve</id>
         <label>Maximum preserved files</label>
         <type>text</type>
-        <help>Number of logs to preserve. When no maximum file size is offered or the logs are smaller than the the size requested, this equals the number of days.</help>
+        <help>Number of logs to preserve. When no maximum file size is offered or the logs are smaller than the size requested, this equals the number of days.</help>
     </field>
     <field>
         <id>syslog.general.maxfilesize</id>

--- a/src/opnsense/service/configd_ctl.py
+++ b/src/opnsense/service/configd_ctl.py
@@ -58,6 +58,7 @@ def exec_config_cmd(exec_command):
         syslog_error('unable to connect to configd socket (@%s)'%configd_socket_name)
         print('unable to connect to configd socket (@%s)'%configd_socket_name, file=sys.stderr)
         yield None
+        return
 
     try:
         sock.send(exec_command.encode())
@@ -145,12 +146,12 @@ else:
     for exec_command in exec_commands:
         if args.d:
             exec_command = '&' + exec_command
-        endmarker = (chr(0), chr(0), chr(0))
+        endmarker = chr(0) * 3
         for block in exec_config_cmd(exec_command=exec_command):
             if block is None:
                 sys.exit(-1)
             elif not args.q:
                 if block.endswith(endmarker):
-                    print(block[:-3].rstrip())
+                    print(block[:-len(endmarker)].rstrip())
                 else:
                     print(block, end="")

--- a/src/opnsense/service/modules/processhandler.py
+++ b/src/opnsense/service/modules/processhandler.py
@@ -51,7 +51,7 @@ class Handler(object):
 
         processflow:
             Handler ( waits for client )
-                -> new client is send to HandlerClient
+                -> new client is sent to HandlerClient
                     -> execute ActionHandler command using BaseAction type objects (delivered via ActionFactory)
                     <- send back result string
     """

--- a/src/opnsense/service/tests/core.py
+++ b/src/opnsense/service/tests/core.py
@@ -106,7 +106,7 @@ class TestCoreMethods(unittest.TestCase):
         self.dummysock = None
 
     def test_escape_sequence(self):
-        """ test if "end of data" is send correctly
+        """ test if "end of data" is sent correctly
         :return:
         """
         # send unknown command

--- a/src/opnsense/site-python/duckdb_helper.py
+++ b/src/opnsense/site-python/duckdb_helper.py
@@ -147,7 +147,7 @@ def export_database(source, target, owner_uid='root', owner_gid='wheel'):
     with DbConnection(source, read_only=True) as db:
         if db is not None and db.connection is not None:
             os.makedirs(target, mode=0o750, exist_ok=True)
-            shutil.chown(target, 'unbound', 'unbound')
+            shutil.chown(target, owner_uid, owner_gid)
             db.connection.execute("EXPORT DATABASE '%s';" % target)
             for filename in glob.glob('%s/*'% target):
                 shutil.chown(filename, owner_uid, owner_gid)


### PR DESCRIPTION
## Summary
Summary

-The contribution guide now advises users to “join ongoing discussions” when a similar issue already exists

-The firewall code comment in filter.inc correctly states “check for an error” when loading rules

-The syslog form help text no longer repeats “the” when describing file size limits

-configd_ctl.py returns immediately after yielding None when the socket is unavailable and properly slices using an end marker string

-Process handler comments note that a “new client is sent to HandlerClient” for clarity

-The escape sequence test docstring states that “end of data” is sent correctly

-export_database now applies the supplied UID and GID to the target directory and exported files